### PR TITLE
Enable benchHandler on "/bench/" in addition of "/bench"

### DIFF
--- a/app.go
+++ b/app.go
@@ -53,6 +53,7 @@ func main() {
 	http.HandleFunc("/data", dataHandler)
 	http.HandleFunc("/echo", echoHandler)
 	http.HandleFunc("/bench", benchHandler)
+	http.HandleFunc("/bench/", benchHandler)
 	http.HandleFunc("/", whoamiHandler)
 	http.HandleFunc("/api", apiHandler)
 	http.HandleFunc("/health", healthHandler)


### PR DESCRIPTION
Adding the trailing slash allows to trigger the bench handler for
performance measurements in situations where a trailing slash
character '/' is added to the request.

For example, in traefik addPrefix middleware, if you specify a
"/bench" prefix, a request on "http://localhost" will be transformed
from "GET /" to "GET /bench/" with no way to remove the trailing
'/' (at least without adding another rewrite rule, which would
modify measurements).