### PR TITLE
Support non-root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,4 +23,4 @@ COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /go/whoami/whoami .
 
 ENTRYPOINT ["/whoami"]
-EXPOSE 80
+EXPOSE 8000

--- a/app.go
+++ b/app.go
@@ -55,7 +55,7 @@ func init() {
 	flag.StringVar(&cert, "cert", "", "give me a certificate")
 	flag.StringVar(&key, "key", "", "give me a key")
 	flag.StringVar(&ca, "cacert", "", "give me a CA chain, enforces mutual TLS")
-	flag.StringVar(&port, "port", getEnv("WHOAMI_PORT_NUMBER", "80"), "give me a port number")
+	flag.StringVar(&port, "port", getEnv("WHOAMI_PORT_NUMBER", "8000"), "give me a port number")
 	flag.StringVar(&name, "name", os.Getenv("WHOAMI_NAME"), "give me a name")
 }
 


### PR DESCRIPTION
binding on port 80 needs root or extended capabilities. changing to a higher port supports non-root execution.

already attempted in https://github.com/traefik/whoami/pull/18 , stale due unresponsiveness of pull request creator