### PR TITLE
feat: Replace data fillcontent with custom reader

### DIFF
--- a/app.go
+++ b/app.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bytes"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
@@ -181,7 +180,7 @@ func dataHandler(w http.ResponseWriter, r *http.Request) {
 		attachment = false
 	}
 
-	content := fillContent(size)
+	content := &contentReader{size: size}
 
 	if attachment {
 		w.Header().Set("Content-Disposition", "Attachment")
@@ -309,22 +308,6 @@ func healthHandler(w http.ResponseWriter, req *http.Request) {
 		defer mutexHealthState.RUnlock()
 		w.WriteHeader(currentHealthState.StatusCode)
 	}
-}
-
-func fillContent(length int64) io.ReadSeeker {
-	charset := "-ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-	b := make([]byte, length)
-
-	for i := range b {
-		b[i] = charset[i%len(charset)]
-	}
-
-	if length > 0 {
-		b[0] = '|'
-		b[length-1] = '|'
-	}
-
-	return bytes.NewReader(b)
 }
 
 func getEnv(key, fallback string) string {

--- a/content.go
+++ b/content.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"errors"
+	"io"
+)
+
+const contentCharset = "-ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+type contentReader struct {
+	size int64
+	cur  int64
+}
+
+// Read implements the io.Read interface.
+func (d *contentReader) Read(p []byte) (n int, err error) {
+	length := d.size - 1
+	if d.cur >= length {
+		return 0, io.EOF
+	}
+	if len(p) == 0 {
+		return 0, nil
+	}
+
+	if d.cur == 0 {
+		p[n] = '|'
+		d.cur++
+		n++
+	}
+
+	for n < len(p) && d.cur <= length {
+
+		p[n] = contentCharset[int(d.cur)%len(contentCharset)]
+		d.cur++
+		n++
+	}
+
+	if d.cur >= length {
+		p[n-1] = '|'
+	}
+
+	return
+}
+
+// Seek implements the io.Seek interface.
+func (d *contentReader) Seek(offset int64, whence int) (int64, error) {
+	switch whence {
+	default:
+		return 0, errors.New("Seek: invalid whence")
+	case io.SeekStart:
+		offset += 0
+	case io.SeekCurrent:
+		offset += d.cur
+	case io.SeekEnd:
+		offset += d.size - 1
+	}
+	if offset < 0 {
+		return 0, errors.New("Seek: invalid offset")
+	}
+	d.cur = offset
+	return offset, nil
+}

--- a/content_test.go
+++ b/content_test.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"io"
+	"testing"
+)
+
+func Test_contentReader_Read(t *testing.T) {
+	tests := []struct {
+		name    string
+		size    int64
+		content string
+	}{
+		{
+			name:    "simple",
+			size:    40,
+			content: "|ABCDEFGHIJKLMNOPQRSTUVWXYZ-ABCDEFGHIJK|",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := &contentReader{
+				size: tt.size,
+			}
+
+			b, err := io.ReadAll(d)
+			if err != nil {
+				t.Errorf("contentReader.Read() error = %v", err)
+				return
+			}
+
+			if string(b) != tt.content {
+				t.Errorf("return content does not match expected value: %s vs %s", tt.content, b)
+			}
+		})
+	}
+}
+
+func Test_contentReader_ReadSeek(t *testing.T) {
+	tests := []struct {
+		name       string
+		offset     int64
+		seekWhence int
+		size       int64
+		content    string
+	}{
+		{
+			name:       "simple",
+			offset:     10,
+			seekWhence: io.SeekCurrent,
+			size:       40,
+			content:    "JKLMNOPQRSTUVWXYZ-ABCDEFGHIJK|",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := &contentReader{
+				size: tt.size,
+			}
+			_, err := d.Seek(tt.offset, tt.seekWhence)
+			if err != nil {
+				t.Errorf("contentReader.Seek() error = %v", err)
+				return
+			}
+
+			b, err := io.ReadAll(d)
+			if err != nil {
+				t.Errorf("contentReader.Read() error = %v", err)
+				return
+			}
+
+			if string(b) != tt.content {
+				t.Errorf("return content does not match expected value: %s vs %s", tt.content, b)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The current data endpoint is bad implemented and has several issues what
can cause performance issues or even crash the app with Out of memory.

This adds a proper SeekReader to properly stream the data to a client

This might be related to #54. 