### PR TITLE
show more log variables: User-Agent, X-Forwarded-For and Referer for verbose logging

### DIFF
--- a/app.go
+++ b/app.go
@@ -125,8 +125,11 @@ func handle(next http.HandlerFunc, verbose bool) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		next(w, r)
 
-		// <remote_IP_address> - [<timestamp>] "<request_method> <request_path> <request_protocol>" -
-		log.Printf("%s - - [%s] \"%s %s %s\" - -", r.RemoteAddr, time.Now().Format("02/Jan/2006:15:04:05 -0700"), r.Method, r.URL.Path, r.Proto)
+		// <remote_IP_address> - - [<timestamp>] "<request_method> <request_path> <request_protocol>" "<http_referer>" "<http_user_agent>" "<x_forwarded_for>"
+		ref := r.Header.Get("Referer"); if ref         == "" { ref = "-" }
+		ua  := r.Header.Get("User-Agent"); if ua       == "" { ua = "-" }
+		xff := r.Header.Get("X-Forwarded-For"); if xff == "" { xff = "-" }
+		log.Printf("%s - - [%s] \"%s %s %s\" \"%s\" \"%s\" \"%s\"", r.RemoteAddr, time.Now().Format("02/Jan/2006:15:04:05 -0700"), r.Method, r.URL.Path, r.Proto, ref, ua, xff)
 	})
 }
 


### PR DESCRIPTION
when setting up a proxy service like nginx/traefik, we want to make sure some useful headers(such as User-Agent, X-Forwarded-For and Referer) are config correctly by checking the verbose logging, for example:

```
# start whoami in verbose mode
$ ./whoami --port 1024 --verbose
```

```
curl -H "Referer: http://example.com" -H "X-Forwarded-For:127.0.0.1"  http://localhost:1024/api
```

here is the log example from whoami and nginx:

```
nginx-whoami-1  | 2023/08/06 15:25:00 172.30.0.3:44140 - - [06/Aug/2023:15:25:00 +0000] "GET /api HTTP/1.0" - -
nginx           | 172.30.0.1 - - [06/Aug/2023:15:25:00 +0000] "GET /whoami/api HTTP/1.1" 200 324 "http://example.com" "curl/7.88.1" "127.0.0.1"
```

with this change, we should see `whoami` output logs like:

```
2023/08/06 23:21:53 127.0.0.1:58551 - - [06/Aug/2023:23:21:53 +0800] "GET /api HTTP/1.1" "http://example.com" "curl/7.88.1" "127.0.0.1"
```

without User-Agent, X-Forwarded-For and Referer:
 
```
curl -A "" http://localhost:1024/api
```

will get logs like:

```
2023/08/06 23:21:53 127.0.0.1:58550 - - [06/Aug/2023:23:21:53 +0800] "GET /api HTTP/1.1" "-" "-" "-"
```