### PR TITLE
feat: allow CORS

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,14 +47,15 @@ Heath check.
 
 ### Flags
 
-| Flag      | Env var              | Description                             |
-|-----------|----------------------|-----------------------------------------|
-| `cert`    |                      | Give me a certificate.                  |
-| `key`     |                      | Give me a key.                          |
-| `cacert`  |                      | Give me a CA chain, enforces mutual TLS |
-| `port`    | `WHOAMI_PORT_NUMBER` | Give me a port number. (default: `80`)  |
-| `name`    | `WHOAMI_NAME`        | Give me a name.                         |
-| `verbose` |                      | Enable verbose logging.                 |
+| Flag              | Env var                  | Description                                       |
+| ----------------- | ------------------------ | ------------------------------------------------- |
+| `cert`            |                          | Give me a certificate.                            |
+| `key`             |                          | Give me a key.                                    |
+| `cacert`          |                          | Give me a CA chain, enforces mutual TLS           |
+| `port`            | `WHOAMI_PORT_NUMBER`     | Give me a port number. (default: `80`)            |
+| `name`            | `WHOAMI_NAME`            | Give me a name.                                   |
+| `verbose`         |                          | Enable verbose logging.                           |
+| `allowed-origins` | `WHOAMI_ALLOWED_ORIGINS` | Give me a list of allowed origins. (default: `*`) |
 
 ## Examples
 
@@ -89,7 +90,7 @@ $ curl -v http://localhost:80/health
 > Host: localhost:80
 > User-Agent: curl/7.65.3
 > Accept: */*
-> 
+>
 * Mark bundle as not supporting multiuse
 < HTTP/1.1 500 Internal Server Error
 < Date: Mon, 16 Sep 2019 22:52:40 GMT
@@ -101,13 +102,13 @@ docker run -d -P -v ./certs:/certs --name iamfoo traefik/whoami --cert /certs/ex
 ```
 
 ```yml
-version: '3.9'
+version: "3.9"
 
 services:
   whoami:
     image: traefik/whoami
     command:
-       # It tells whoami to start listening on 2001 instead of 80
-       - --port=2001
-       - --name=iamfoo
+      # It tells whoami to start listening on 2001 instead of 80
+      - --port=2001
+      - --name=iamfoo
 ```


### PR DESCRIPTION
Added an option to allow cors origin for the `/api` endpoint
- added the optional `WHOAMI_ALLOWED_ORIGINS` environmental variable to whitelist origins.
- added the optional `allowed-origns` flag to whitelist origins.
- the default value of the whitelist is `*`, ie to allow all origins.