### PR TITLE
Add optional query param for adding headers to the server's response

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,16 @@ Tiny Go webserver that prints OS information and HTTP request to output.
 
 ### Paths
 
-#### `/[?wait=d]`
+#### `/[?wait=d|header=key=value[&header=key=value...]]`
 
 Returns the whoami information (request and network information).
 
 The optional `wait` query parameter can be provided to tell the server to wait before sending the response.
 The duration is expected in Go's [`time.Duration`](https://golang.org/pkg/time/#ParseDuration) format (e.g. `/?wait=100ms` to wait 100 milliseconds).
+
+The optional `header` query parameter can be provided to tell the server to add a certain header when sending
+the response. The query param may be passed multiple times (e.g.
+`/?header=Cache-Control=no-cache&header=Content-Type=application%2Fjson`).
 
 The optional `env` query parameter can be set to `true` to add the environment variables to the response.
 

--- a/app.go
+++ b/app.go
@@ -219,6 +219,21 @@ func dataHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+func addHeaderFilter(w http.ResponseWriter, r *http.Request) {
+	queryParams := r.URL.Query()
+
+	if headers, exists := queryParams["header"]; exists {
+		for _, header := range headers {
+			headerName, headerValue, found := strings.Cut(header, "=")
+			if !found {
+				continue
+			}
+
+			w.Header().Add(headerName, headerValue)
+		}
+	}
+}
+
 func whoamiHandler(w http.ResponseWriter, r *http.Request) {
 	queryParams := r.URL.Query()
 
@@ -229,6 +244,8 @@ func whoamiHandler(w http.ResponseWriter, r *http.Request) {
 			time.Sleep(duration)
 		}
 	}
+
+	addHeaderFilter(w, r)
 
 	if name != "" {
 		_, _ = fmt.Fprintln(w, "Name:", name)

--- a/app_test.go
+++ b/app_test.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"slices"
+	"testing"
+)
+
+func TestApp_addHeaderFilter(t *testing.T) {
+	tests := []struct {
+		desc     string
+		params   map[string][]string
+		expected http.Header
+	}{
+		{
+			desc: "single header",
+			params: map[string][]string{
+				"Content-Type": {"application/json"},
+			},
+			expected: http.Header{
+				"Content-Type": []string{"application/json"},
+			},
+		},
+		{
+			desc: "multiple headers",
+			params: map[string][]string{
+				"Content-Type":  {"application/json"},
+				"Cache-Control": {"no-store"},
+			},
+			expected: http.Header{
+				"Content-Type":  []string{"application/json"},
+				"Cache-Control": []string{"no-store"},
+			},
+		},
+		{
+			desc: "duplicate headers",
+			params: map[string][]string{
+				"Content-Type":  {"application/json"},
+				"Cache-Control": {"no-store", "no-cache"},
+			},
+			expected: http.Header{
+				"Content-Type":  []string{"application/json"},
+				"Cache-Control": []string{"no-store", "no-cache"},
+			},
+		},
+		{
+			desc: "special encoded headers",
+			params: map[string][]string{
+				"X-Custom-Field": {"equal=one"},
+			},
+			expected: http.Header{
+				"X-Custom-Field": []string{"equal=one"},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			uri, err := url.Parse("/random-path")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			query := uri.Query()
+
+			for k, values := range test.params {
+				for _, v := range values {
+					query.Add("header", fmt.Sprintf("%s=%s", k, v))
+				}
+			}
+
+			uri.RawQuery = query.Encode()
+
+			req := httptest.NewRequest(http.MethodGet, uri.String(), http.NoBody)
+			w := httptest.NewRecorder()
+			addHeaderFilter(w, req)
+
+			for k, v := range w.Header() {
+				if slices.Compare(test.expected.Values(k), v) != 0 {
+					t.Errorf("header %s doesn't match: got %v, expected %v", k, v, test.expected.Values(k))
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add a feature to allow setting response headers via query params.

Derived from #31.