### PR TITLE
New feature: Mask IP addresses 

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,14 +47,15 @@ Heath check.
 
 ### Flags
 
-| Flag      | Env var              | Description                             |
-|-----------|----------------------|-----------------------------------------|
-| `cert`    |                      | Give me a certificate.                  |
-| `key`     |                      | Give me a key.                          |
-| `cacert`  |                      | Give me a CA chain, enforces mutual TLS |
-| `port`    | `WHOAMI_PORT_NUMBER` | Give me a port number. (default: `80`)  |
-| `name`    | `WHOAMI_NAME`        | Give me a name.                         |
-| `verbose` |                      | Enable verbose logging.                 |
+| Flag       | Env var              | Description                             |
+|------------|----------------------|-----------------------------------------|
+| `cert`     |                      | Give me a certificate.                  |
+| `key`      |                      | Give me a key.                          |
+| `cacert`   |                      | Give me a CA chain, enforces mutual TLS |
+| `port`     | `WHOAMI_PORT_NUMBER` | Give me a port number. (default: `80`)  |
+| `name`     | `WHOAMI_NAME`        | Give me a name.                         |
+| `verbose`  |                      | Enable verbose logging.                 |
+| `mask-ips` |                      | Do not show IPs.                        |
 
 ## Examples
 

--- a/app.go
+++ b/app.go
@@ -43,6 +43,7 @@ var (
 	port    string
 	name    string
 	verbose bool
+	maskIP  bool
 )
 
 func init() {
@@ -52,6 +53,7 @@ func init() {
 	flag.StringVar(&ca, "cacert", "", "give me a CA chain, enforces mutual TLS")
 	flag.StringVar(&port, "port", getEnv("WHOAMI_PORT_NUMBER", "80"), "give me a port number")
 	flag.StringVar(&name, "name", os.Getenv("WHOAMI_NAME"), "give me a name")
+	flag.BoolVar(&maskIP, "mask-ips", false, "Do not show IPs")
 }
 
 // Data whoami information.
@@ -324,20 +326,23 @@ func getEnv(key, fallback string) string {
 func getIPs() []string {
 	var ips []string
 
-	ifaces, _ := net.Interfaces()
-	for _, i := range ifaces {
-		addrs, _ := i.Addrs()
-		// handle err
-		for _, addr := range addrs {
-			var ip net.IP
-			switch v := addr.(type) {
-			case *net.IPNet:
-				ip = v.IP
-			case *net.IPAddr:
-				ip = v.IP
-			}
-			if ip != nil {
-				ips = append(ips, ip.String())
+	// Mask IPs if the flag is set.
+	if !maskIP {
+		ifaces, _ := net.Interfaces()
+		for _, i := range ifaces {
+			addrs, _ := i.Addrs()
+			// handle err
+			for _, addr := range addrs {
+				var ip net.IP
+				switch v := addr.(type) {
+				case *net.IPNet:
+					ip = v.IP
+				case *net.IPAddr:
+					ip = v.IP
+				}
+				if ip != nil {
+					ips = append(ips, ip.String())
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Whoami cannot be used behind CDN Providers as it will leak IP addresses of the origin server.

In this PR, I created a new flag called `mask-ips`, which, if used, will prevent IP addresses from being displayed in the output.