### PR TITLE
feat: add `PORT` environment variable (#92).

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,14 +47,14 @@ Heath check.
 
 ### Flags
 
-| Flag      | Env var              | Description                             |
-|-----------|----------------------|-----------------------------------------|
-| `cert`    |                      | Give me a certificate.                  |
-| `key`     |                      | Give me a key.                          |
-| `cacert`  |                      | Give me a CA chain, enforces mutual TLS |
-| `port`    | `WHOAMI_PORT_NUMBER` | Give me a port number. (default: `80`)  |
-| `name`    | `WHOAMI_NAME`        | Give me a name.                         |
-| `verbose` |                      | Enable verbose logging.                 |
+| Flag      | Env var                     | Description                             |
+|-----------|-----------------------------|-----------------------------------------|
+| `cert`    |                             | Give me a certificate.                  |
+| `key`     |                             | Give me a key.                          |
+| `cacert`  |                             | Give me a CA chain, enforces mutual TLS |
+| `port`    | `WHOAMI_PORT_NUMBER`,`PORT` | Give me a port number. (default: `80`)  |
+| `name`    | `WHOAMI_NAME`               | Give me a name.                         |
+| `verbose` |                             | Enable verbose logging.                 |
 
 ## Examples
 

--- a/app.go
+++ b/app.go
@@ -55,7 +55,7 @@ func init() {
 	flag.StringVar(&cert, "cert", "", "give me a certificate")
 	flag.StringVar(&key, "key", "", "give me a key")
 	flag.StringVar(&ca, "cacert", "", "give me a CA chain, enforces mutual TLS")
-	flag.StringVar(&port, "port", getEnv("WHOAMI_PORT_NUMBER", "80"), "give me a port number")
+	flag.StringVar(&port, "port", getEnv("WHOAMI_PORT_NUMBER", getEnv("PORT", "80")), "give me a port number")
 	flag.StringVar(&name, "name", os.Getenv("WHOAMI_NAME"), "give me a name")
 }
 


### PR DESCRIPTION
Closes #92.
As described there, honoring `PORT` enables seamless self-configuration under most PaaS and serverless hostings.
Keeping `WHOAMI_PORT_NUMBER` precedence first and `80` as default port to preserve current behavior. 